### PR TITLE
Allow `puppetlabs/stdlib` 6.x

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -9,7 +9,7 @@
   "issues_url": "https://github.com/hercules-team/augeasproviders_core/issues",
   "description": "This module provides alternative providers for core Puppet types using the Augeas configuration API library.",
   "dependencies": [
-    {"name":"puppetlabs/stdlib","version_requirement":">= 3.2.0 < 6.0.0"}
+    {"name":"puppetlabs/stdlib","version_requirement":">= 3.2.0 < 7.0.0"}
   ],
   "operatingsystem_support": [
     {


### PR DESCRIPTION
I can't immediately see where stdlib is used in *this* module, but `augeasproviders_core` is a dependency of all other `augeasproviders_X` modules.