### PR TITLE
Add array split_by option

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -216,6 +216,22 @@ If you need the sub-node to be removed rather than cleared when the value is set
     )
 
 
+##### Array value as string
+
+When you wish to expose your attribute as an array and Augeas stores it as
+a string, you can use the `:array` type combined with the `:split_by`
+parameter:
+
+    attr_aug_access(:foo,
+      :type     => :array,
+      :split_by => ','
+    )
+
+will get the value of the `foo` subnode in the Augeas tree and split it on
+commas to return an array of values. Commas will again be used to join values
+when writing them to the tree.
+
+
 ##### Array value
 
 Augeas has two ways of representing array values in its trees, using either fix labels or sequential entries (see [this page](http://www.redhat.com/archives/augeas-devel/2011-February/msg00053.html) for an explanation of why both of them exist).

--- a/lib/puppet/provider/augeasprovider/default.rb
+++ b/lib/puppet/provider/augeasprovider/default.rb
@@ -326,7 +326,7 @@ Puppet::Type.type(:augeasprovider).provide(:default) do
           aug.clear(rpath)
         end
       when :array
-        if args[0].empty?
+        if args[0].nil? || args[0].empty?
           aug.rm(rpath)
         else
           if split_by

--- a/lib/puppet/provider/augeasprovider/default.rb
+++ b/lib/puppet/provider/augeasprovider/default.rb
@@ -222,6 +222,7 @@ Puppet::Type.type(:augeasprovider).provide(:default) do
     default = opts[:default] || nil
     type = opts[:type] || :string
     sublabel = opts[:sublabel] || nil
+    split_by = opts[:split_by] || nil
 
     rpath = label == :resource ? '$resource' : "$resource/#{label}"
 
@@ -241,18 +242,22 @@ Puppet::Type.type(:augeasprovider).provide(:default) do
       when :string
         aug.get(rpath)
       when :array
-        aug.match(rpath).map do |p|
-          if sublabel.nil?
-            aug.get(p)
-          else
-            if sublabel == :seq
-              sp = "#{p}/*[label()=~regexp('[0-9]+')]"
+        if split_by
+          (aug.get(rpath) || "").split(split_by)
+        else
+          aug.match(rpath).map do |p|
+            if sublabel.nil?
+              aug.get(p)
             else
-              sp = "#{p}/#{sublabel}"
+              if sublabel == :seq
+                sp = "#{p}/*[label()=~regexp('[0-9]+')]"
+              else
+                sp = "#{p}/#{sublabel}"
+              end
+              aug.match(sp).map { |spp| aug.get(spp) }
             end
-            aug.match(sp).map { |spp| aug.get(spp) }
-          end
-        end.flatten
+          end.flatten
+        end
       when :hash
         values = {}
         aug.match(rpath).each do |p|
@@ -294,6 +299,7 @@ Puppet::Type.type(:augeasprovider).provide(:default) do
     sublabel = opts[:sublabel] || nil
     purge_ident = opts[:purge_ident] || false
     rm_node = opts[:rm_node] || false
+    split_by = opts[:split_by] || nil
 
     rpath = label == :resource ? '$resource' : "$resource/#{label}"
 
@@ -320,10 +326,12 @@ Puppet::Type.type(:augeasprovider).provide(:default) do
           aug.clear(rpath)
         end
       when :array
-        if args[0].nil?
+        if args[0].empty?
           aug.rm(rpath)
         else
-          if sublabel.nil?
+          if split_by
+            aug.set(rpath, args[0].join(split_by))
+          elsif sublabel.nil?
             aug.rm(rpath)
             count = 0
             args[0].each do |v|

--- a/spec/unit/puppet/provider/augeasprovider/default_spec.rb
+++ b/spec/unit/puppet/provider/augeasprovider/default_spec.rb
@@ -530,6 +530,16 @@ describe provider_class do
         end
       end
 
+      it "should create a class method using :array with :split_by" do
+        subject.attr_aug_reader(:foo, { :type => :array, :split_by => ',' })
+        subject.method_defined?('attr_aug_reader_foo').should be true
+
+        subject.augopen(resource) do |aug|
+          aug.expects(:get).with('$resource/foo').returns('baz,bazz')
+          subject.attr_aug_reader_foo(aug).should == ['baz', 'bazz']
+        end
+      end
+
       it "should create a class method using :array and no sublabel" do
         subject.attr_aug_reader(:foo, { :type => :array })
         subject.method_defined?('attr_aug_reader_foo').should be true
@@ -623,6 +633,25 @@ describe provider_class do
         subject.augopen(resource) do |aug|
           aug.expects(:set).with('$resource/foo', 'bar')
           subject.attr_aug_writer_foo(aug, 'bar')
+          aug.expects(:rm).with('$resource/foo')
+          subject.attr_aug_writer_foo(aug)
+        end
+      end
+
+      it "should create a class method using :array with :split_by" do
+        subject.attr_aug_writer(:foo, { :type => :array, :split_by => ',' })
+        subject.method_defined?('attr_aug_writer_foo').should be true
+
+        subject.augopen(resource) do |aug|
+          # one value
+          aug.expects(:set).with('$resource/foo', 'bar')
+          subject.attr_aug_writer_foo(aug, ['bar'])
+          # multiple values
+          aug.expects(:set).with('$resource/foo', 'bar,baz')
+          subject.attr_aug_writer_foo(aug, ['bar', 'baz'])
+          # purge values
+          aug.expects(:rm).with('$resource/foo')
+          subject.attr_aug_writer_foo(aug, [])
           aug.expects(:rm).with('$resource/foo')
           subject.attr_aug_writer_foo(aug)
         end


### PR DESCRIPTION
When you wish to expose your attribute as an array and Augeas stores it as      
a string, you can use the `:array` type combined with the `:split_by`           
parameter:                                                                      
                                                                                
    attr_aug_access(:foo,                                                       
      :type     => :array,                                                      
      :split_by => ','                                                          
    )                                                                           
                                                                                
will get the value of the `foo` subnode in the Augeas tree and split it on      
commas to return an array of values. Commas will again be used to join values   
when writing them to the tree.    