### PR TITLE
Add Debian 10 and Red Hat 8 to the supported OS list

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -17,7 +17,8 @@
       "operatingsystemrelease": [
         "7",
         "8",
-        "9"
+        "9",
+        "10"
       ]
     },
     {
@@ -34,7 +35,17 @@
       "operatingsystemrelease": [
         "5",
         "6",
-        "7"
+        "7",
+        "8"
+      ]
+    },
+    {
+      "operatingsystem": "CentOS",
+      "operatingsystemrelease": [
+        "5",
+        "6",
+        "7",
+        "8"
       ]
     }
   ],


### PR DESCRIPTION
This also adds CentOS since it's equivalent to Red Hat.

I'm not sure about the regular procedure to add distro support. I don't see any acceptance tests and don't have the capacity to properly test this myself.