### PR TITLE
Allow stdlib 8.0.0

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -10,7 +10,7 @@
   "dependencies": [
     {
       "name": "puppetlabs/stdlib",
-      "version_requirement": ">= 3.2.0 < 8.0.0"
+      "version_requirement": ">= 3.2.0 < 9.0.0"
     }
   ],
   "operatingsystem_support": [


### PR DESCRIPTION
Puppet released a new major version of the stdlib module.

Allowing the latest version of stdlib in the module would allow other modules which depend on it to use this new version of the module.
